### PR TITLE
Should do a cutout from the photo during classification as resize skews photo

### DIFF
--- a/ei_run_impulse.cpp
+++ b/ei_run_impulse.cpp
@@ -313,7 +313,7 @@ void run_nn(bool debug) {
 
         ei::signal_t signal;
         signal.total_length = EI_CLASSIFIER_RAW_SAMPLE_COUNT;
-        signal.get_data = &cutout_get_data;
+        signal.get_data = &ei_cutout_get_data;
 
         ei_printf("Taking photo...\n");
 

--- a/sensors/ei_camera.cpp
+++ b/sensors/ei_camera.cpp
@@ -78,24 +78,41 @@ void ei_camera_deinit(void)
  *
  * @param[in]  img_width     width of output image
  * @param[in]  img_height    height of output image
- * @param[out] fb_cols       pointer to frame buffer column/width value
- * @param[out] fb_rows       pointer to frame buffer rows/height value
+ * @param[out] fb_cols       pointer to frame buffer's column/width value
+ * @param[out] fb_rows       pointer to frame buffer's rows/height value
  *
 * @todo Remove magic numbers
  */
 void calculate_rescaled_fb_resolution (uint32_t img_width, uint32_t img_height, uint32_t *fb_cols, uint32_t *fb_rows)
 {
-    if ((img_width == FRAME_BUFFER_COLS) && (img_height == FRAME_BUFFER_ROWS)
-        || (img_width > 320) && (img_height > 240)
-    ) {
+
+    const ei_device_snapshot_resolutions_t *list;
+    size_t list_size;
+
+    int dl = EiDevice.get_snapshot_list((const ei_device_snapshot_resolutions_t **)&list, &list_size);
+    if (dl) { /* apparently false is OK here?! */
+        ei_printf("ERR: Device has no snapshot feature\n");
+        return;
+    }
+
+    uint32_t fb_width;
+    uint32_t fb_height;
+    bool fb_resolution_found = false;
+    for (size_t ix = 0; ix < list_size; ix++) {
+        if ((img_width <= list[ix].width) || (img_height <= list[ix].height)) {
+            fb_width  = list[ix].width;
+            fb_height = list[ix].height;
+            fb_resolution_found = true;
+            break;
+        }
+    }
+
+    if (fb_resolution_found) {
+        *fb_cols = fb_width;
+        *fb_rows = fb_height;
+    } else {
         *fb_cols = FRAME_BUFFER_COLS;
         *fb_rows = FRAME_BUFFER_ROWS;
-    } else if ((img_width > 128) && (img_height > 96)) {
-        *fb_cols = 320;
-        *fb_rows = 240;
-    } else {
-        *fb_cols = 128;
-        *fb_rows =  96;
     }
 }
 
@@ -120,22 +137,25 @@ bool ei_camera_capture(uint32_t img_width, uint32_t img_height, int8_t *buf)
         return false;
     }
 
-    // skip scaling if width and height matches the original resolution
-    if ((img_width == FRAME_BUFFER_COLS) && (img_height == FRAME_BUFFER_ROWS)) return true;
-
+    // determine what the scaled output image buffer size should be
     calculate_rescaled_fb_resolution(img_width, img_height, &frame_buffer_cols, &frame_buffer_rows);
+    cutout_row_start = (frame_buffer_rows - img_height) / 2;
+    cutout_col_start = (frame_buffer_cols - img_width) / 2;
+    cutout_cols = img_width;
+    cutout_rows = img_height;
+
+    //  skip scaling if frame buffer's width and height matches the original resolution
+    if ((frame_buffer_cols == FRAME_BUFFER_COLS) && (frame_buffer_rows == FRAME_BUFFER_ROWS)) return true;
+
     if (hx_drv_image_rescale((uint8_t*)g_pimg_config.raw_address,
                              g_pimg_config.img_width, g_pimg_config.img_height,
                              buf, frame_buffer_cols, frame_buffer_rows) != HX_DRV_LIB_PASS) {
         return false;
     }
 
-    snapshot_is_resized = (img_width != FRAME_BUFFER_COLS) || (img_height != FRAME_BUFFER_ROWS);
+    // always assign
+    snapshot_is_resized = (frame_buffer_cols != FRAME_BUFFER_COLS) || (frame_buffer_rows != FRAME_BUFFER_ROWS);
 
-    cutout_row_start = (frame_buffer_rows - img_height) / 2;
-    cutout_col_start = (frame_buffer_cols - img_width) / 2;
-    cutout_cols = img_width;
-    cutout_rows = img_height;
     return true;
 }
 
@@ -183,7 +203,7 @@ bool ei_camera_take_snapshot(size_t width, size_t height)
 
     ei::signal_t signal;
     signal.total_length = width * height;
-    signal.get_data = &cutout_get_data;
+    signal.get_data = &ei_cutout_get_data;
 
     size_t signal_chunk_size = 1024;
 

--- a/sensors/ei_camera.h
+++ b/sensors/ei_camera.h
@@ -83,7 +83,7 @@ static void mono_to_rgb(uint8_t mono_data, uint8_t *r, uint8_t *g, uint8_t *b) {
  * This function is called by the classifier to get data
  * We don't want to have a separate copy of the cutout here, so we'll read from the frame buffer dynamically
  */
-static int cutout_get_data(size_t offset, size_t length, float *out_ptr) {
+static int ei_cutout_get_data(size_t offset, size_t length, float *out_ptr) {
     // so offset and length naturally operate on the *cutout*, so we need to cut it out from the real framebuffer
     size_t bytes_left = length;
     size_t out_ptr_ix = 0;


### PR DESCRIPTION
If we resize to 96x96 pixels the image gets skewed, which distorts the result. We should instead sample at (e.g.) 128x96 pixels and then cutout the interesting part of the photo ourselves, as done in https://github.com/edgeimpulse/example-signal-from-rgb565-frame-buffer.