### PR TITLE
Do rescale on 640x480 to reorder pixels correctly

### DIFF
--- a/ingestion-sdk-platform/himax/ei_himax_fs_commands.cpp
+++ b/ingestion-sdk-platform/himax/ei_himax_fs_commands.cpp
@@ -2,6 +2,7 @@
 /* Include ----------------------------------------------------------------- */
 #include "ei_himax_fs_commands.h"
 #include "ei_device_himax.h"
+#include "ei_camera.h"
 
 
 #define SERIAL_FLASH	0
@@ -27,7 +28,12 @@ static void flash_program_page(uint32_t byteAddress, uint8_t *page, uint32_t pag
 static uint32_t flash_read_data(uint32_t byteAddress, uint8_t *buffer, uint32_t readBytes);
 
 #if(SAMPLE_MEMORY == RAM)
-volatile uint8_t * const raw_memory_2 = (uint8_t *) (0x20124e70); // pointer to g_pimg_config.raw_address
+
+/*
+ * initialised by ei_camera_init()
+ */
+extern hx_drv_sensor_image_config_t g_pimg_config;
+
 #pragma Bss(".ram_memory")
 uint8_t ram_memory[SIZE_RAM_BUFFER];
 #pragma Bss()
@@ -237,7 +243,7 @@ uint8_t *ei_himax_fs_allocate_sampledata(size_t n_bytes)
     }
     // explicitly used for image data for now
     else if (n_bytes == SIZE_RAM2_BUFFER) {
-        return (uint8_t *)raw_memory_2;
+        return (uint8_t *)g_pimg_config.raw_address;
     }
     else if (n_bytes >= SIZE_RAM_BUFFER) {
         return 0;

--- a/sensors/ei_camera.cpp
+++ b/sensors/ei_camera.cpp
@@ -29,11 +29,12 @@
 #include "at_base64.h"
 #include "numpy_types.h"
 
-#include "hx_drv_tflm.h"
+
+/* Global variables ------------------------------------------------------- */
+hx_drv_sensor_image_config_t g_pimg_config;
 
 /* Private variables ------------------------------------------------------- */
 static bool is_initialised = false;
-static hx_drv_sensor_image_config_t g_pimg_config;
 static int8_t *snapshot_image_data = NULL;
 
 /* Private functions ------------------------------------------------------- */
@@ -43,9 +44,12 @@ static int get_snapshot_image_data(size_t offset, size_t length, float *out_ptr)
     for(size_t i = 0; i < length; i++) {
         int8_t mono_data = (int8_t)snapshot_image_data[offset + i];
         uint8_t v;
-
-        v = (uint8_t)mono_data + 128;
-
+        if (snapshot_is_resized) {
+            v = (uint8_t)mono_data + 128;
+        }
+        else {
+            v = (uint8_t)mono_data;
+        }
         out_ptr[i] = (float)((v << 16) | (v << 8) | (v));
     }
 
@@ -108,6 +112,9 @@ bool ei_camera_capture(uint32_t img_width, uint32_t img_height, int8_t *buf)
         return false;
     }
 
+    // skip scaling if width and height matches the original resolution
+    if ((img_width == 640) && (img_height == 480)) return true;
+
     if (hx_drv_image_rescale((uint8_t*)g_pimg_config.raw_address,
                              g_pimg_config.img_width, g_pimg_config.img_height,
                              buf, img_width, img_height) != HX_DRV_LIB_PASS) {
@@ -140,18 +147,19 @@ bool ei_camera_take_snapshot(size_t width, size_t height)
         return false;
     }
 
-    snapshot_image_data = (int8_t*)ei_himax_fs_allocate_sampledata(width * height);
-    if (!snapshot_image_data) {
-        ei_printf("ERR: Failed to allocate image buffer\n");
-        return false;
-    }
-
     ei_printf("\tImage resolution: %dx%d\n", width, height);
 
     snapshot_is_resized = (width != 640) || (height != 480);
 
     if (ei_camera_init() == false) {
         ei_printf("ERR: Failed to initialize image sensor\r\n");
+        return false;
+    }
+
+    // must be called after ei_camera_init()
+    snapshot_image_data = (int8_t*)ei_himax_fs_allocate_sampledata(width * height);
+    if (!snapshot_image_data) {
+        ei_printf("ERR: Failed to allocate image buffer for (%dx%d): 0x%x\n", width, height, snapshot_image_data);
         return false;
     }
 

--- a/sensors/ei_camera.h
+++ b/sensors/ei_camera.h
@@ -26,6 +26,10 @@
 /* Include ----------------------------------------------------------------- */
 #include <stdint.h>
 #include <stdlib.h>
+#include "hx_drv_tflm.h"
+
+/* Global variables ------------------------------------------------------- */
+extern hx_drv_sensor_image_config_t g_pimg_config;
 
 /* Function prototypes ----------------------------------------------------- */
 extern bool ei_camera_init(void);


### PR DESCRIPTION
See issue #23 
This pull request calls the rescale function although no rescaling has to be performed. 

@rajames 
Input and output buffers are the same, this seems to work but please double check. And maybe I missed something else..